### PR TITLE
Enabled modifier keys on the first mouse button.

### DIFF
--- a/block.cpp
+++ b/block.cpp
@@ -125,9 +125,15 @@ void Block::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
 // ---------------------------------------------------------------------------
 
 void Block::mousePressEvent(QGraphicsSceneMouseEvent *p_Event) {
+  unsigned button = 0;
   this->resetBrushStyle();
 
-  int nIndex(m_pSettings->getMouseControls().indexOf(p_Event->button()));
+  if (p_Event)
+      button = p_Event->button();
+  if (button == Qt::LeftButton)
+      button |= p_Event->modifiers();
+
+  int nIndex(m_pSettings->getMouseControls().indexOf(button));
   if (nIndex >= 0) {
     switch (nIndex) {
       case 0:

--- a/settings.cpp
+++ b/settings.cpp
@@ -60,6 +60,12 @@ Settings::Settings(QWidget *pParent, QString sSharePath)
   m_listMouseButtons << Qt::XButton1 << Qt::XButton2
                      << (quint8(Qt::Vertical) | nSHIFT)
                      << (quint8(Qt::Horizontal) | nSHIFT);
+  m_sListMouseButtons << tr("Left + Shift") << tr("Left + Ctrl")
+                      << tr("Left + Alt") << tr("Left + Meta");
+  m_listMouseButtons << ((unsigned) Qt::LeftButton | Qt::ShiftModifier)
+                     << ((unsigned) Qt::LeftButton | Qt::ControlModifier)
+                     << ((unsigned) Qt::LeftButton | Qt::AltModifier)
+                     << ((unsigned) Qt::LeftButton | Qt::MetaModifier);
   m_pUi->cbRotateBlockMouse->addItems(m_sListMouseButtons);
   m_pUi->cbFlipBlockMouse->addItems(m_sListMouseButtons);
 


### PR DESCRIPTION
Simple fix to provide more input options for those using trackpads (who may prefer to disable middle-button emulation), Apple mice, alternative input devices, etc.  I set it up to only check the modifiers on presses of the first mouse button, but it would be easy to expand further.